### PR TITLE
Update Link to FAC - non-relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 JustOpine is a tool to get students talking about current events. Through the platform, teachers are able to assign opinion pieces for students to respond to and discuss.
 
-The tech team for this project is based at [Founders & Coders London](www.foundersandcoders.com).
+The tech team for this project is based at [Founders & Coders London](http://www.foundersandcoders.com/).
 
 ## Tech Stack
 


### PR DESCRIPTION
Clicking the link would take user to a github 404 because it was simply tacking on the domain etc to the url.

Adding the protocol makes it actually go to FAC
